### PR TITLE
単語の揺れの削減とストップワード除去

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,10 +5,14 @@ import matplotlib.pyplot as plt
 
 from database import fetchData
 from doc2vec import clustering
+from stopwords import maybe_download
 
 
 if not os.path.exists('./data/hateb.csv'):
     fetchData()
+
+if not os.path.exists("./data/stop.txt"):
+    maybe_download("./data/stop.txt")
 
 if not os.path.exists('./data/hateb_cluster.csv'):
     clustering(sys.argv[1])

--- a/src/normalization.py
+++ b/src/normalization.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# https://qiita.com/Hironsan/items/2466fe0f344115aff177
+import re
+import unicodedata
+
+import nltk
+from nltk.corpus import wordnet
+
+
+def normalize(text):
+    normalized_text = normalize_unicode(text)
+    normalized_text = normalize_number(normalized_text)
+    normalized_text = lower_text(normalized_text)
+    return normalized_text
+
+
+def lower_text(text):
+    return text.lower()
+
+
+def normalize_unicode(text, form='NFKC'):
+    normalized_text = unicodedata.normalize(form, text)
+    return normalized_text
+
+
+def lemmatize_term(term, pos=None):
+    if pos is None:
+        synsets = wordnet.synsets(term)
+        if not synsets:
+            return term
+        pos = synsets[0].pos()
+        if pos == wordnet.ADJ_SAT:
+            pos = wordnet.ADJ
+    return nltk.WordNetLemmatizer().lemmatize(term, pos=pos)
+
+
+def normalize_number(text):
+    """
+    pattern = r'\d+'
+    replacer = re.compile(pattern)
+    result = replacer.sub('0', text)
+    """
+    # 連続した数字を0で置換
+    replaced_text = re.sub(r'\d+', '0', text)
+    return replaced_text

--- a/src/stopwords.py
+++ b/src/stopwords.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+# https://qiita.com/Hironsan/items/2466fe0f344115aff177
+import os
+import urllib.request
+from collections import Counter
+
+from gensim import corpora
+
+
+def maybe_download(path):
+    url = 'http://svn.sourceforge.jp/svnroot/slothlib/CSharp/Version1/SlothLib/NLP/Filter/StopWord/word/Japanese.txt'
+    if os.path.exists(path):
+        print('File already exists.')
+    else:
+        print('Downloading stopwordlist')
+        # Download the file from `url` and save it locally under `file_name`:
+        urllib.request.urlretrieve(url, path)
+
+
+def create_dictionary(texts):
+    dictionary = corpora.Dictionary(texts)
+    return dictionary
+
+
+def remove_stopwords(words, stopwords):
+    words = [word for word in words if word not in stopwords]
+    return words
+
+
+def most_common(docs, n=100):
+    fdist = Counter()
+    for doc in docs:
+        for word in doc:
+            fdist[word] += 1
+    common_words = {word for word, freq in fdist.most_common(n)}
+    print('{}/{}'.format(n, len(fdist)))
+    return common_words
+
+
+def get_stop_words(docs, n=100, min_freq=1):
+    fdist = Counter()
+    for doc in docs:
+        for word in doc:
+            fdist[word] += 1
+    common_words = {word for word, freq in fdist.most_common(n)}
+    rare_words = {word for word, freq in fdist.items() if freq <= min_freq}
+    stopwords = common_words.union(rare_words)
+    print('{}/{}'.format(len(stopwords), len(fdist)))
+    return stopwords


### PR DESCRIPTION
単語の表記の揺れ(英単語の大文字小文字、辞書を用いた単語の統一、数字を全て0に）
簡易なストップワードの除去

を入れました。
https://qiita.com/Hironsan/items/2466fe0f344115aff177
